### PR TITLE
Added multiline syntax to yml file

### DIFF
--- a/java-8-base-filebeat/filebeat.yml
+++ b/java-8-base-filebeat/filebeat.yml
@@ -13,6 +13,10 @@ filebeat.prospectors:
   encoding: utf-8
   exclude_files: [".gz"]
   ignore_older: 3h
+  # Catches java exceptions by insisting all new lines start with a date
+  multiline.pattern: '^[0-9]{4}-[0-9]{2}-[0-9]{2}'
+  multiline.negate: true
+  multiline.match: after
 
 output.logstash:
     hosts: ${FILEBEAT_HOSTS}


### PR DESCRIPTION
Assumes that a new line starts with a date, as per log4j.  This means exceptions and lines that do not start with a date will appear in the same kibana entry.