### PR TITLE
changed the filebeat version in docker file

### DIFF
--- a/java-8-base-filebeat/Dockerfile
+++ b/java-8-base-filebeat/Dockerfile
@@ -28,7 +28,7 @@ RUN 	echo "deb https://artifacts.elastic.co/packages/6.x/apt stable main" | tee 
 
 # Update all dependencies and install filebeat
 RUN     apt-get update && \
-		apt-get install filebeat -y
+		apt-get install filebeat=6.2.4 -y
 
 COPY 	./filebeat.yml /etc/filebeat/filebeat.yml
 RUN		chmod 644 /etc/filebeat/filebeat.yml


### PR DESCRIPTION
Temporary fix for the file beat service specifying the version of filebeat to install in to the container.  The latest version of file beat is broken and is causing issues getting logs into kibana.  Have gone back to last known stable version